### PR TITLE
TRITON-2221 Fix TypeError when invoking `triton rbac info`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,13 @@ Known issues:
 
 ## not yet released
 
+- No changes yet
+
+## 7.15.2
+
 - TRITON-1389 node-triton test failures
 - TOOLS-2543 MNX Tooling updates
+- TRITON-2221 Fix TypeError when invoking triton rbac info.
 
 ## 7.15.1
 

--- a/lib/rbac.js
+++ b/lib/rbac.js
@@ -394,11 +394,19 @@ function loadRbacState(ctx, cb) {
             }
             for (i = 0; i < rbacState.roles.length; i++) {
                 var role = rbacState.roles[i];
-                role.default_members.forEach(function (login) {
-                    userFromLogin[login].default_roles.push(role.name);
-                });
-                role.members.forEach(function (login) {
-                    userFromLogin[login].roles.push(role.name);
+
+                // role.default_members may not be set and is likely only set
+                // when this function is called via `triton rbac apply` with an
+                // rbac configuration JSON file (in which case it still may not
+                // be set) See: examples/rbac-simple/rbac.json
+                if (role.default_members && role.default_members.length) {
+                    role.default_members.forEach(function (login) {
+                        userFromLogin[login].default_roles.push(role.name);
+                    });
+                }
+
+                role.members.forEach(function (member) {
+                    userFromLogin[member.login].roles.push(role.name);
                 });
             }
             next();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "triton",
   "description": "Triton CLI and client (https://www.tritondatacenter.com/)",
-  "version": "7.15.1",
+  "version": "7.15.2",
   "author": "MNX Cloud (mnx.io)",
   "homepage": "https://github.com/TritonDataCenter/node-triton",
   "dependencies": {


### PR DESCRIPTION
When invoking `triton rbac info` using a profile that has at least one role and one subuser the command will fail with a TypeError.

Add check for existence of property and fix another previously unreached bug where an object was being indexed by another object instead of a string.